### PR TITLE
BUGFIX: Import errors

### DIFF
--- a/app/models/inspection.rb
+++ b/app/models/inspection.rb
@@ -13,9 +13,10 @@ class Inspection
      i = Inspection.new
      i.date = payload["date"]
      i.result= payload["result"]
-     i.number_of_infractions = payload["numInfractions"]
+     i.number_of_infractions = 0 
+     i.number_of_infractions = payload["numInfractions"] unless payload['numInfractions'].empty?
      i.save
-     if payload["infractions"]
+     unless payload["infractions"].empty?
          payload["infractions"].each do |inf|
              infraction = Infraction.from_json(inf)
              infraction.inspection = i


### PR DESCRIPTION
Here is a sample Import error 

```
FAILED TO PARSE DAYCARE
undefined method `each' for "":String
{"type"=>"Child Care - Pre School", "centerName"=>"ECO 4 KIDS LLC ", "permitHolder"=>"ECO 4 KIDS LLC", "address"=>"4712 AVENUE N", "borough"=>"BROOKLYN", "zipCode"=>"11234", "phone"=>"718-252-8400", "permitStatus"=>" Permitted ", "permitNumber"=>"99877", "permitExpirationDate"=>" 11/13/2017", "ageRange"=>"2 - 5", "maximumCapacity"=>"19", "siteType"=>"Private", "certifiedToAdministerMedication"=>"No", "yearsOperating"=>"1", "hasInspections"=>"false", "latestInspection"=>{"date"=>"", "result"=>"", "infractions"=>"", "numInfractions"=>""}, "numInspections"=>"0", "pastInspections"=>"", "latitude"=>40.618769028588, "longitude"=>-73.929558240697}

2044 records imported
256 failed to import
```

There were 256 import errors that fail on something silly like .each on an empty string. A couple of checks were put in place and we are good to go now. Maybe It would be nice to set the correct defaults at the scraping script level.. But this should do for now. 
