### PR TITLE
updated codes

### DIFF
--- a/app/models/infraction.rb
+++ b/app/models/infraction.rb
@@ -36,7 +36,11 @@ class Infraction
   data = CSV.read("data/simplified_health_codes.csv", { encoding: "UTF-8", headers: true, header_converters: :symbol, converters: :all})
   data.map { |d|
     d = d.to_hash
-    simplified_code = d[:code].gsub(/[^0-9a-z ]/i, '')
+    simplified_code  = d[:code].gsub(/[^0-9a-z\\s]/i, '')
+    reformatted_code = ""
+    reformatted_code = d[:code_reformatted].to_s.gsub(/[^0-9a-z\\s]/i, '') unless d[:code_reformatted].nil?
+    simplified_code  = reformatted_code if reformatted_code.length > simplified_code.length
+    puts "s: #{d[:code].gsub(/[^0-9a-z\\s]/i, '')} r: #{reformatted_code} sc:#{simplified_code}"
     @@simplified_codes[simplified_code] = d
   }
 


### PR DESCRIPTION
(using code and reformatted code while importing)

This PR brings down the unmatched codes from 691 to 103!! huge win. 

```ruby
["4723 ab", "4723 ab", "4723 ab", "8121 f", "4812ab1", "14102b", "8121 b", "8137 ab", "4809b12", "14102b", "8119 ab", "4723 ab", "8109 ab", "8121 b", "4723 ab", "8119 ab", "4723 ab", "4723 ab", "14313b", "8121 c", "4723 ab", "4723 ab", "4723 ab", "4715 ab", " ", "4809f12", "4723 ab", "8137 e", "8119 ab", "4723 ab", "8119 ab", " ", "4723 ab", "8119 ab", "4723 ab", "8121 c", "8119 ab", "8119 ab", "4723 ab", "8137 c", "4723 ab", "8119 ab", "4809f34gh", "4809f34gh", "4809f12", "4723 ab", "4723 ab", "4723 ab", "4723 ab", "4723 ab", "4723 ab", "4723 ab", "4723 ab", "4723 ab", "4723 ab", "8129 d", "4723 ab", "8121 f", " ", "4723 ab", "4809f12", " ", "8119 ab", " ", " ", "4715 ab", "4723 ab", "8137 d", "8119 ab", "4723 ab", "4723 ab", "4809f12", "8119 ab", "8121 b", "4723 ab", "8119 ab", "4723 ab", "4723 ab", "14102b", "4809f12", "4723 ab", "4723 ab", "8119 ab", "8121 f", "4723 ab", "4809b4iii", "4809b12", "4715 ab", "4809b4iii", "4723 ab", "8137 c", "8121 b", " ", "8121 e", "8141 ab", " ", "4723 ab", "4809b12", "8119 ab", "4809f34gh", "4809f34gh", "4809f12", "8119 ab"]
```